### PR TITLE
Replace turbolinks with turbo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^8.0|^8.1",
         "illuminate/support": "^9.0",
         "illuminate/view": "^9.0",
-        "rapidez/core": "~0.66"
+        "rapidez/core": "~0.77"
     },
     "autoload": {
         "psr-4": {

--- a/resources/js/gtm.js
+++ b/resources/js/gtm.js
@@ -2,7 +2,7 @@ function removeTrailingZeros(price) {
     return parseFloat(parseFloat(price).toString())
 }
 
-document.addEventListener('turbolinks:load', (event) => {
+document.addEventListener('turbo:load', (event) => {
     if ('dataLayer' in window) {
         window.dataLayer = []
         


### PR DESCRIPTION
Required for the migration from Turbolinks to Turbo in Core.