### PR TITLE
Ensure datalayer providers are imported before sending pageview events

### DIFF
--- a/resources/js/gtm.js
+++ b/resources/js/gtm.js
@@ -1,6 +1,6 @@
 window.removeTrailingZeros = (price) =>  parseFloat(parseFloat(price).toString());
 
-(async () => {
+let dataLayersPromise = (async () => {
     // This async function is in order to work around "ERROR: Top-level await is not available" when building for older browsers.
     window.dataLayers = {
         ua: window.config.gtm['send-ua-events'] ? await import('./datalayer/ua.js') : undefined,
@@ -15,6 +15,7 @@ document.addEventListener('turbo:load', async (event) => {
     if (window.config.gtm['clear-on-load']) {
         window.dataLayer = []
     }
+    await dataLayersPromise
 
     let url = new URL(event.detail.url);
 


### PR DESCRIPTION
On slower networks it could happen that turbo:load is triggered before the event providers have been imported.

This is generally not a problem, and even good. However it may cause "dataLayers is not defined"

So we wait until these are imported