### PR TITLE
Fix dataLayer in window check

### DIFF
--- a/resources/js/gtm.js
+++ b/resources/js/gtm.js
@@ -41,7 +41,7 @@ let dataLayersPromise = (async () => {
 })()
 
 function sendDataLayer(func, ...args) {
-    if (!'dataLayer' in window) {
+    if (!('dataLayer' in window)) {
         return
     }
     


### PR DESCRIPTION
This check will always return false, and thus fail in local environments where dataLayer doesn't get defined (or in situations where it gets blocked).