### PR TITLE
Listen to registered event

### DIFF
--- a/resources/js/gtm.js
+++ b/resources/js/gtm.js
@@ -77,6 +77,10 @@ document.addEventListener('vue:loaded', async () => {
         ga4.beginCheckout()
     }
 
+    window.app.$on('registered', () => {
+       ga4.register()
+    });
+    
     window.app.$on('logged-in', () => {
         ga4.login()
     })


### PR DESCRIPTION
The ga4 function existed already but was left unused as there was no registered event fired yet. This has changed thus it can be listened to